### PR TITLE
uart_wired_update_sparkfun.py: Discard buffered data before hello

### DIFF
--- a/bsp/tools/uart_wired_update_sparkfun.py
+++ b/bsp/tools/uart_wired_update_sparkfun.py
@@ -39,6 +39,8 @@ def main():
 
     with serial.Serial(args.port, args.baud, timeout=12) as ser:
         time.sleep(0.25) # delay for 250ms
+        ser.reset_output_buffer()
+        ser.reset_input_buffer()
         connect_device(ser)
 
     print('Done.')


### PR DESCRIPTION
Discard buffered serial data after opening serial interface.
Especially useful for overwriting firmware with serial output like example1_edge_test.

Tested on: Ubuntu 18.04 with FTDI USB